### PR TITLE
Remove invalid BoxScope align import

### DIFF
--- a/app/src/main/java/com/example/practicas/MainActivity.kt
+++ b/app/src/main/java/com/example/practicas/MainActivity.kt
@@ -19,7 +19,6 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
-import androidx.compose.foundation.layout.BoxScope.align
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height


### PR DESCRIPTION
## Summary
- remove the invalid BoxScope.align import from MainActivity to allow Compose compilation

## Testing
- Not run (network restriction downloading Gradle wrapper)


------
https://chatgpt.com/codex/tasks/task_e_68db0b5cddf483268b2c391f0e0d3d61