### PR TITLE
Fix background brush initialization

### DIFF
--- a/app/src/main/java/com/example/practicas/MainActivity.kt
+++ b/app/src/main/java/com/example/practicas/MainActivity.kt
@@ -606,11 +606,12 @@ fun NFLApp() {
 
 @Composable
 fun ConferenceSelectionScreen(onConferenceSelected: (Conference) -> Unit) {
-    val backgroundBrush = remember {
+    val colorScheme = MaterialTheme.colorScheme
+    val backgroundBrush = remember(colorScheme) {
         Brush.verticalGradient(
             listOf(
-                MaterialTheme.colorScheme.surfaceVariant,
-                MaterialTheme.colorScheme.background
+                colorScheme.surfaceVariant,
+                colorScheme.background
             )
         )
     }


### PR DESCRIPTION
## Summary
- capture the MaterialTheme color scheme outside of the remember block to avoid composable access in a non-composable context
- memoize the gradient brush using the color scheme as a key

## Testing
- `./gradlew compileDebugKotlin` *(fails: Gradle distribution download blocked by proxy)*

------
https://chatgpt.com/codex/tasks/task_e_68db1186c9f48326bdd4cd748858cde2