### PR TITLE
Create dark modern NFL multi-screen Compose mockups

### DIFF
--- a/app/src/main/java/com/example/practicas/MainActivity.kt
+++ b/app/src/main/java/com/example/practicas/MainActivity.kt
@@ -4,9 +4,11 @@ import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
+import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.horizontalScroll
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -24,32 +26,58 @@ import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.ArrowBack
+import androidx.compose.material.icons.rounded.BarChart
+import androidx.compose.material.icons.rounded.Home
+import androidx.compose.material.icons.rounded.Leaderboard
+import androidx.compose.material.icons.rounded.SportsFootball
+import androidx.compose.material.icons.rounded.Upcoming
+import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.CenterAlignedTopAppBar
+import androidx.compose.material3.Divider
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.NavigationBar
+import androidx.compose.material3.NavigationBarItem
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Surface
+import androidx.compose.material3.Tab
+import androidx.compose.material3.TabRow
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.text.style.TextDecoration
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import androidx.navigation.NavDestination.Companion.hierarchy
+import androidx.navigation.NavGraph.Companion.findStartDestination
 import androidx.navigation.NavType
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
+import androidx.navigation.compose.currentBackStackEntryAsState
 import androidx.navigation.compose.rememberNavController
 import androidx.navigation.navArgument
+import com.example.practicas.R
 import com.example.practicas.ui.theme.PracticasTheme
 
 enum class Conference(val displayName: String) {
@@ -530,17 +558,441 @@ object TeamsRepository {
         teamsInternal.filter { it.conference == conference }
 
     fun getTeamById(id: String): Team? = teamsById[id]
+
+    fun getAllTeams(): List<Team> = teamsInternal
 }
 
-sealed class Screen(val route: String) {
-    data object ConferenceSelection : Screen("conference-selection")
-    data object ConferenceTeams : Screen("conference-teams/{conference}") {
-        fun createRoute(conference: Conference) = "conference-teams/${conference.name}"
-    }
-    data object TeamDetail : Screen("team-detail/{teamId}") {
-        fun createRoute(teamId: String) = "team-detail/$teamId"
-    }
+private fun playerSlug(name: String): String = name
+    .lowercase()
+    .replace("á", "a")
+    .replace("é", "e")
+    .replace("í", "i")
+    .replace("ó", "o")
+    .replace("ú", "u")
+    .replace("ñ", "n")
+    .replace("&", "and")
+    .replace("'", "")
+    .replace(".", "")
+    .replace(" ", "-")
+
+data class PlayerProfile(
+    val id: String,
+    val name: String,
+    val teamId: String,
+    val position: String,
+    val awards: String,
+    val biography: String,
+    val headshotRes: Int = R.drawable.nfl
+)
+
+data class GoatPlayer(
+    val rank: Int,
+    val name: String,
+    val position: String,
+    val debutYear: Int,
+    val teamId: String
+)
+
+data class GoatTeam(
+    val rank: Int,
+    val name: String,
+    val season: String,
+    val teamId: String
+)
+
+enum class GameStatus { Final, Upcoming }
+
+data class DivisionStanding(
+    val teamId: String,
+    val record: String,
+    val trend: String
+)
+
+data class Game(
+    val id: String,
+    val homeTeamId: String,
+    val awayTeamId: String,
+    val status: GameStatus,
+    val homeScore: Int?,
+    val awayScore: Int?,
+    val date: String,
+    val location: String,
+    val homeRecord: String,
+    val awayRecord: String,
+    val odds: String,
+    val keyStats: List<Pair<String, String>>,
+    val divisionStandings: List<DivisionStanding>
+)
+
+data class StatRow(
+    val label: String,
+    val values: List<String>
+)
+
+data class StatCategory(
+    val title: String,
+    val headers: List<String>,
+    val rows: List<StatRow>
+)
+
+object LogoAssets {
+    private val teamLogos = mapOf(
+        "bills" to R.drawable.buffalo_bills,
+        "dolphins" to R.drawable.miami_dolphins,
+        "patriots" to R.drawable.new_england_patriots,
+        "jets" to R.drawable.new_york_jets,
+        "ravens" to R.drawable.baltimore_ravens,
+        "bengals" to R.drawable.cincinnati_bengals,
+        "browns" to R.drawable.cleveland_browns,
+        "steelers" to R.drawable.pittsburgh_steelers,
+        "texans" to R.drawable.houston_texans,
+        "colts" to R.drawable.indianapolis_colts,
+        "jaguars" to R.drawable.jacksonville_jaguars,
+        "titans" to R.drawable.tennessee_titans,
+        "chiefs" to R.drawable.kansas_city_chiefs,
+        "chargers" to R.drawable.san_diego_chargers,
+        "cowboys" to R.drawable.dallas_cowboys,
+        "giants" to R.drawable.new_york_giants,
+        "eagles" to R.drawable.philadelphia_eagles,
+        "commanders" to R.drawable.washington_commanders,
+        "bears" to R.drawable.chicago_bears,
+        "lions" to R.drawable.detroit_lions,
+        "packers" to R.drawable.green_bay_packers,
+        "vikings" to R.drawable.minnesota_vikings,
+        "saints" to R.drawable.new_orleans_saints,
+        "buccaneers" to R.drawable.tampa_bay_buccaneers,
+        "cardinals" to R.drawable.arizona_cardinals,
+        "rams" to R.drawable.st_louis_rams,
+        "49ers" to R.drawable.san_francisco_49ers,
+        "seahawks" to R.drawable.seattle_seahawks
+    )
+
+    fun teamLogo(teamId: String): Int = teamLogos[teamId] ?: R.drawable.nfl
 }
+
+object PlayersRepository {
+    private val featuredProfiles = listOf(
+        PlayerProfile(
+            id = playerSlug("Tom Brady"),
+            name = "Tom Brady",
+            teamId = "patriots",
+            position = "QB",
+            awards = "7× Super Bowl, 3× MVP, 5× Super Bowl MVP",
+            biography = "Tom Brady redefinió la dinastía de los New England Patriots y estableció la vara de la longevidad en la NFL.",
+            headshotRes = R.drawable.new_england_patriots
+        ),
+        PlayerProfile(
+            id = playerSlug("Patrick Mahomes"),
+            name = "Patrick Mahomes",
+            teamId = "chiefs",
+            position = "QB",
+            awards = "2× MVP, 3× Campeón del Super Bowl",
+            biography = "Mahomes combina creatividad y brazo élite para mantener a los Chiefs como la ofensiva más explosiva de la liga.",
+            headshotRes = R.drawable.kansas_city_chiefs
+        ),
+        PlayerProfile(
+            id = playerSlug("Jerry Rice"),
+            name = "Jerry Rice",
+            teamId = "49ers",
+            position = "WR",
+            awards = "3× Super Bowl, Líder histórico en recepciones y yardas",
+            biography = "Jerry Rice dominó la posición de receptor abierto con disciplina y química perfecta con Joe Montana y Steve Young.",
+            headshotRes = R.drawable.san_francisco_49ers
+        ),
+        PlayerProfile(
+            id = playerSlug("Lawrence Taylor"),
+            name = "Lawrence Taylor",
+            teamId = "giants",
+            position = "LB",
+            awards = "2× Super Bowl, MVP 1986, 10× Pro Bowl",
+            biography = "LT revolucionó la defensiva moderna con agresividad inigualable y redefinió el rol del pass rusher.",
+            headshotRes = R.drawable.new_york_giants
+        ),
+        PlayerProfile(
+            id = playerSlug("Walter Payton"),
+            name = "Walter Payton",
+            teamId = "bears",
+            position = "RB",
+            awards = "MVP 1977, Super Bowl XX, 9× Pro Bowl",
+            biography = "Sweetness combinó resistencia, elegancia y corazón para liderar a los Bears dentro y fuera del campo.",
+            headshotRes = R.drawable.chicago_bears
+        ),
+        PlayerProfile(
+            id = playerSlug("Ray Lewis"),
+            name = "Ray Lewis",
+            teamId = "ravens",
+            position = "LB",
+            awards = "2× Super Bowl, 2× Defensive POY",
+            biography = "Ray Lewis dio identidad a los Ravens con liderazgo vocal y ferocidad en cada snap.",
+            headshotRes = R.drawable.baltimore_ravens
+        ),
+        PlayerProfile(
+            id = playerSlug("Peyton Manning"),
+            name = "Peyton Manning",
+            teamId = "colts",
+            position = "QB",
+            awards = "5× MVP, 2× Campeón del Super Bowl",
+            biography = "Manning llevó la ofensiva cerebral de los Colts a niveles históricos con precisión quirúrgica.",
+            headshotRes = R.drawable.indianapolis_colts
+        ),
+        PlayerProfile(
+            id = playerSlug("Barry Sanders"),
+            name = "Barry Sanders",
+            teamId = "lions",
+            position = "RB",
+            awards = "MVP 1997, 10× Pro Bowl",
+            biography = "Los cortes imposibles de Barry Sanders encendieron a Detroit y lo convirtieron en mito viviente.",
+            headshotRes = R.drawable.detroit_lions
+        ),
+        PlayerProfile(
+            id = playerSlug("Aaron Donald"),
+            name = "Aaron Donald",
+            teamId = "rams",
+            position = "DL",
+            awards = "Super Bowl LVI, 3× Defensive POY",
+            biography = "Aaron Donald domina las trincheras con fuerza bruta y técnica impecable desde el interior defensivo.",
+            headshotRes = R.drawable.st_louis_rams
+        ),
+        PlayerProfile(
+            id = playerSlug("Josh Allen"),
+            name = "Josh Allen",
+            teamId = "bills",
+            position = "QB",
+            awards = "2× Pro Bowl, Jugador Ofensivo AFC",
+            biography = "Allen mezcla físico imponente y brazo láser para encender a Bills Mafia en cada jugada.",
+            headshotRes = R.drawable.buffalo_bills
+        ),
+        PlayerProfile(
+            id = playerSlug("Justin Jefferson"),
+            name = "Justin Jefferson",
+            teamId = "vikings",
+            position = "WR",
+            awards = "Ofensivo del Año 2022, 3× Pro Bowl",
+            biography = "JJettas convirtió el griddy en símbolo de una nueva generación de receptores dominantes en Minnesota.",
+            headshotRes = R.drawable.minnesota_vikings
+        )
+    ).associateBy { it.id }
+
+    fun highlightsFor(team: Team): List<PlayerProfile> = team.notablePlayers.map { name ->
+        val slug = playerSlug(name)
+        featuredProfiles[slug] ?: createGenericProfile(team, name, slug)
+    }
+
+    fun getProfileById(teamId: String, playerId: String): PlayerProfile? {
+        val team = TeamsRepository.getTeamById(teamId) ?: return null
+        val featured = featuredProfiles[playerId]
+        if (featured != null) {
+            return if (featured.teamId == teamId) featured else featured.copy(teamId = teamId)
+        }
+        val playerName = team.notablePlayers.firstOrNull { playerSlug(it) == playerId }
+            ?: return null
+        return createGenericProfile(team, playerName, playerId)
+    }
+
+    private fun createGenericProfile(team: Team, name: String, slug: String): PlayerProfile =
+        PlayerProfile(
+            id = slug,
+            name = name,
+            teamId = team.id,
+            position = "Figura histórica",
+            awards = "Premios múltiples y legado en ${team.city}",
+            biography = "$name dejó huella en los ${team.city} ${team.name} con actuaciones decisivas y liderazgo ejemplar."
+        )
+}
+
+object GamesRepository {
+    private val games = listOf(
+        Game(
+            id = "chiefs-bills-divisional",
+            homeTeamId = "chiefs",
+            awayTeamId = "bills",
+            status = GameStatus.Final,
+            homeScore = 27,
+            awayScore = 24,
+            date = "Dom, 21 Ene · Arrowhead Stadium",
+            location = "Kansas City, MO",
+            homeRecord = "12-5",
+            awayRecord = "13-4",
+            odds = "KC -2.5 · O/U 48.5",
+            keyStats = listOf(
+                "Patrick Mahomes" to "312 YDS · 3 TD",
+                "Josh Allen" to "289 YDS · 2 TD",
+                "Total Yards" to "KC 421 - BUF 407"
+            ),
+            divisionStandings = listOf(
+                DivisionStanding("chiefs", "12-5", "▲1"),
+                DivisionStanding("broncos", "8-9", "="),
+                DivisionStanding("raiders", "6-11", "▼1"),
+                DivisionStanding("chargers", "5-12", "▼1")
+            )
+        ),
+        Game(
+            id = "49ers-ravens-superbowl",
+            homeTeamId = "49ers",
+            awayTeamId = "ravens",
+            status = GameStatus.Final,
+            homeScore = 31,
+            awayScore = 28,
+            date = "Dom, 11 Feb · Allegiant Stadium",
+            location = "Las Vegas, NV",
+            homeRecord = "14-4",
+            awayRecord = "15-3",
+            odds = "SF -1.5 · O/U 47.0",
+            keyStats = listOf(
+                "Christian McCaffrey" to "142 YDS Totales · 2 TD",
+                "Lamar Jackson" to "3 TD Totales",
+                "Turnovers" to "SF 1 - BAL 2"
+            ),
+            divisionStandings = listOf(
+                DivisionStanding("49ers", "13-4", "▲1"),
+                DivisionStanding("seahawks", "9-8", "="),
+                DivisionStanding("rams", "9-8", "▲1"),
+                DivisionStanding("cardinals", "4-13", "▼1")
+            )
+        ),
+        Game(
+            id = "jets-dolphins-week1",
+            homeTeamId = "jets",
+            awayTeamId = "dolphins",
+            status = GameStatus.Upcoming,
+            homeScore = null,
+            awayScore = null,
+            date = "Dom, 8 Sep · 13:00 ET",
+            location = "MetLife Stadium",
+            homeRecord = "0-0",
+            awayRecord = "0-0",
+            odds = "MIA -1.5 · O/U 46.0",
+            keyStats = listOf(
+                "Claves" to "Reaparición de Aaron Rodgers",
+                "Duelo" to "Hill vs Sauce Gardner",
+                "Clima" to "Prob. lluvia ligera"
+            ),
+            divisionStandings = listOf(
+                DivisionStanding("bills", "0-0", "-"),
+                DivisionStanding("dolphins", "0-0", "-"),
+                DivisionStanding("jets", "0-0", "-"),
+                DivisionStanding("patriots", "0-0", "-")
+            )
+        ),
+        Game(
+            id = "cowboys-eagles-week4",
+            homeTeamId = "cowboys",
+            awayTeamId = "eagles",
+            status = GameStatus.Upcoming,
+            homeScore = null,
+            awayScore = null,
+            date = "Dom, 29 Sep · 20:20 ET",
+            location = "AT&T Stadium",
+            homeRecord = "0-0",
+            awayRecord = "0-0",
+            odds = "EVEN · O/U 49.5",
+            keyStats = listOf(
+                "Duelo" to "Prescott vs Hurts",
+                "Ritmo" to "Dallas 31.2 PPG en casa",
+                "Clave" to "Pass rush Eagles"
+            ),
+            divisionStandings = listOf(
+                DivisionStanding("eagles", "0-0", "-"),
+                DivisionStanding("cowboys", "0-0", "-"),
+                DivisionStanding("giants", "0-0", "-"),
+                DivisionStanding("commanders", "0-0", "-")
+            )
+        )
+    )
+
+    fun gamesByStatus(status: GameStatus): List<Game> = games.filter { it.status == status }
+
+    fun getGameById(id: String): Game? = games.firstOrNull { it.id == id }
+}
+
+object GoatRankingsRepository {
+    val goatPlayers = listOf(
+        GoatPlayer(1, "Tom Brady", "QB", 2000, "patriots"),
+        GoatPlayer(2, "Jerry Rice", "WR", 1985, "49ers"),
+        GoatPlayer(3, "Lawrence Taylor", "LB", 1981, "giants"),
+        GoatPlayer(4, "Walter Payton", "RB", 1975, "bears"),
+        GoatPlayer(5, "Peyton Manning", "QB", 1998, "colts"),
+        GoatPlayer(6, "Ray Lewis", "LB", 1996, "ravens"),
+        GoatPlayer(7, "Joe Montana", "QB", 1979, "49ers"),
+        GoatPlayer(8, "Deion Sanders", "CB", 1989, "cowboys"),
+        GoatPlayer(9, "Reggie White", "DE", 1984, "packers"),
+        GoatPlayer(10, "Barry Sanders", "RB", 1989, "lions")
+    )
+
+    val goatTeams = listOf(
+        GoatTeam(1, "Chicago Bears", "1985", "bears"),
+        GoatTeam(2, "New England Patriots", "2007", "patriots"),
+        GoatTeam(3, "San Francisco 49ers", "1989", "49ers"),
+        GoatTeam(4, "Pittsburgh Steelers", "1978", "steelers"),
+        GoatTeam(5, "Kansas City Chiefs", "2022", "chiefs"),
+        GoatTeam(6, "Dallas Cowboys", "1993", "cowboys"),
+        GoatTeam(7, "Baltimore Ravens", "2000", "ravens"),
+        GoatTeam(8, "Denver Broncos", "1998", "broncos"),
+        GoatTeam(9, "New York Giants", "1990", "giants"),
+        GoatTeam(10, "Green Bay Packers", "1966", "packers")
+    )
+}
+
+object StatsRepository {
+    val categories = listOf(
+        StatCategory(
+            title = "Passing",
+            headers = listOf("Jugador", "TD", "INT", "YDS", "% Comp"),
+            rows = listOf(
+                StatRow("Patrick Mahomes (KC)", listOf("38", "9", "4,950", "67.4")),
+                StatRow("Joe Burrow (CIN)", listOf("34", "10", "4,385", "69.2")),
+                StatRow("Josh Allen (BUF)", listOf("36", "14", "4,720", "65.1")),
+                StatRow("Tua Tagovailoa (MIA)", listOf("33", "9", "4,534", "68.8"))
+            )
+        ),
+        StatCategory(
+            title = "Rushing",
+            headers = listOf("Jugador", "TD", "YDS", "AVG", "Carries"),
+            rows = listOf(
+                StatRow("Derrick Henry (TEN)", listOf("16", "1,445", "4.7", "307")),
+                StatRow("Christian McCaffrey (SF)", listOf("14", "1,380", "4.9", "281")),
+                StatRow("Nick Chubb (CLE)", listOf("12", "1,328", "5.2", "256")),
+                StatRow("Saquon Barkley (NYG)", listOf("10", "1,242", "4.6", "270"))
+            )
+        ),
+        StatCategory(
+            title = "Receiving",
+            headers = listOf("Jugador", "REC", "YDS", "TD", "YAC"),
+            rows = listOf(
+                StatRow("Justin Jefferson (MIN)", listOf("122", "1,809", "10", "598")),
+                StatRow("Tyreek Hill (MIA)", listOf("119", "1,732", "9", "611")),
+                StatRow("Ja'Marr Chase (CIN)", listOf("108", "1,421", "12", "512")),
+                StatRow("CeeDee Lamb (DAL)", listOf("105", "1,357", "9", "482"))
+            )
+        ),
+        StatCategory(
+            title = "Defense",
+            headers = listOf("Jugador", "Tackles", "Sacks", "INT", "FF"),
+            rows = listOf(
+                StatRow("Micah Parsons (DAL)", listOf("87", "15.5", "2", "3")),
+                StatRow("T.J. Watt (PIT)", listOf("74", "18.0", "1", "5")),
+                StatRow("Fred Warner (SF)", listOf("118", "6.5", "3", "2")),
+                StatRow("Jalen Ramsey (MIA)", listOf("76", "2.0", "5", "3"))
+            )
+        )
+    )
+}
+
+sealed class RootDestination(val baseRoute: String, val icon: ImageVector, val label: String) {
+    data object Home : RootDestination("home", Icons.Rounded.Home, "Home")
+    data object Teams : RootDestination("teams", Icons.Rounded.SportsFootball, "Equipos")
+    data object Games : RootDestination("games", Icons.Rounded.Upcoming, "Partidos")
+    data object Rankings : RootDestination("rankings", Icons.Rounded.Leaderboard, "GOAT")
+    data object Stats : RootDestination("stats", Icons.Rounded.BarChart, "Stats")
+}
+
+val RootDestinations = listOf(
+    RootDestination.Home,
+    RootDestination.Teams,
+    RootDestination.Games,
+    RootDestination.Rankings,
+    RootDestination.Stats
+)
 
 class MainActivity : ComponentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
@@ -559,268 +1011,474 @@ class MainActivity : ComponentActivity() {
 @Composable
 fun NFLApp() {
     val navController = rememberNavController()
-    NavHost(
-        navController = navController,
-        startDestination = Screen.ConferenceSelection.route
-    ) {
-        composable(Screen.ConferenceSelection.route) {
-            ConferenceSelectionScreen(
-                onConferenceSelected = { conference ->
-                    navController.navigate(Screen.ConferenceTeams.createRoute(conference))
+    val backStackEntry by navController.currentBackStackEntryAsState()
+    val currentRoute = backStackEntry?.destination?.route?.substringBefore("?")
+    val showBottomBar = backStackEntry?.destination?.hierarchy?.any { destination ->
+        val base = destination.route?.substringBefore("?")
+        RootDestinations.any { it.baseRoute == base }
+    } == true
+
+    Scaffold(
+        containerColor = MaterialTheme.colorScheme.background,
+        bottomBar = {
+            if (showBottomBar) {
+                NavigationBar(containerColor = MaterialTheme.colorScheme.surface.copy(alpha = 0.92f)) {
+                    RootDestinations.forEach { destination ->
+                        val selected = currentRoute == destination.baseRoute
+                        NavigationBarItem(
+                            selected = selected,
+                            onClick = {
+                                navController.navigate(destination.baseRoute) {
+                                    popUpTo(navController.graph.findStartDestination().id) {
+                                        saveState = true
+                                    }
+                                    launchSingleTop = true
+                                    restoreState = true
+                                }
+                            },
+                            icon = {
+                                Icon(
+                                    imageVector = destination.icon,
+                                    contentDescription = destination.label
+                                )
+                            },
+                            label = {
+                                Text(text = destination.label)
+                            }
+                        )
+                    }
                 }
-            )
+            }
         }
-        composable(
-            Screen.ConferenceTeams.route,
-            arguments = listOf(navArgument("conference") { type = NavType.StringType })
-        ) { backStackEntry ->
-            val conferenceName = backStackEntry.arguments?.getString("conference")
-            val conference = conferenceName?.let { runCatching { Conference.valueOf(it) }.getOrNull() }
-            if (conference != null) {
-                val teams = remember(conference) { TeamsRepository.getTeamsForConference(conference) }
-                ConferenceTeamsScreen(
-                    conference = conference,
-                    teams = teams,
-                    onBack = { navController.popBackStack() },
-                    onTeamSelected = { team ->
-                        navController.navigate(Screen.TeamDetail.createRoute(team.id))
+    ) { innerPadding ->
+        NavHost(
+            navController = navController,
+            startDestination = RootDestination.Home.baseRoute,
+            modifier = Modifier.padding(innerPadding)
+        ) {
+            composable(RootDestination.Home.baseRoute) {
+                HomeScreen(
+                    onConferenceSelected = { conference ->
+                        navController.navigate("${RootDestination.Teams.baseRoute}?conference=${conference.name}")
+                    },
+                    onExploreGames = {
+                        navController.navigate(RootDestination.Games.baseRoute)
+                    },
+                    onExploreRankings = {
+                        navController.navigate(RootDestination.Rankings.baseRoute)
                     }
                 )
             }
-        }
-        composable(
-            Screen.TeamDetail.route,
-            arguments = listOf(navArgument("teamId") { type = NavType.StringType })
-        ) { backStackEntry ->
-            val teamId = backStackEntry.arguments?.getString("teamId")
-            val team = teamId?.let(TeamsRepository::getTeamById)
-            if (team != null) {
-                TeamDetailScreen(
-                    team = team,
-                    onBack = { navController.popBackStack() }
+            composable(
+                route = "${RootDestination.Teams.baseRoute}?conference={conference}",
+                arguments = listOf(navArgument("conference") {
+                    type = NavType.StringType
+                    nullable = true
+                    defaultValue = null
+                })
+            ) { backStack ->
+                val conference = backStack.arguments?.getString("conference")
+                    ?.let { runCatching { Conference.valueOf(it) }.getOrNull() }
+                    ?: Conference.AFC
+                TeamsScreen(
+                    initialConference = conference,
+                    onTeamSelected = { team ->
+                        navController.navigate("team/${team.id}")
+                    },
+                    onPlayerSelected = { team, player ->
+                        navController.navigate("player/${team.id}/${player.id}")
+                    }
                 )
+            }
+            composable(RootDestination.Games.baseRoute) {
+                GamesScreen(
+                    onGameSelected = { game ->
+                        navController.navigate("game/${game.id}")
+                    }
+                )
+            }
+            composable(RootDestination.Rankings.baseRoute) {
+                RankingsScreen(onTeamSelected = { teamId ->
+                    navController.navigate("team/$teamId")
+                })
+            }
+            composable(RootDestination.Stats.baseRoute) {
+                StatsScreen()
+            }
+            composable(
+                route = "team/{teamId}",
+                arguments = listOf(navArgument("teamId") { type = NavType.StringType })
+            ) { backStack ->
+                val teamId = backStack.arguments?.getString("teamId")
+                val team = teamId?.let(TeamsRepository::getTeamById)
+                if (team != null) {
+                    TeamDetailScreen(
+                        team = team,
+                        onPlayerSelected = { player ->
+                            navController.navigate("player/${team.id}/${player.id}")
+                        },
+                        onBack = { navController.popBackStack() }
+                    )
+                }
+            }
+            composable(
+                route = "player/{teamId}/{playerId}",
+                arguments = listOf(
+                    navArgument("teamId") { type = NavType.StringType },
+                    navArgument("playerId") { type = NavType.StringType }
+                )
+            ) { backStack ->
+                val teamId = backStack.arguments?.getString("teamId")
+                val playerId = backStack.arguments?.getString("playerId")
+                val profile = if (teamId != null && playerId != null) {
+                    PlayersRepository.getProfileById(teamId, playerId)
+                } else null
+                val team = teamId?.let(TeamsRepository::getTeamById)
+                if (profile != null && team != null) {
+                    PlayerDetailScreen(
+                        team = team,
+                        profile = profile,
+                        onBack = { navController.popBackStack() }
+                    )
+                }
+            }
+            composable(
+                route = "game/{gameId}",
+                arguments = listOf(navArgument("gameId") { type = NavType.StringType })
+            ) { backStack ->
+                val gameId = backStack.arguments?.getString("gameId")
+                val game = gameId?.let(GamesRepository::getGameById)
+                if (game != null) {
+                    GameDetailScreen(
+                        game = game,
+                        onBack = { navController.popBackStack() }
+                    )
+                }
             }
         }
     }
 }
 
 @Composable
-fun ConferenceSelectionScreen(onConferenceSelected: (Conference) -> Unit) {
-    val colorScheme = MaterialTheme.colorScheme
-    val backgroundBrush = remember(colorScheme) {
-        Brush.verticalGradient(
-            listOf(
-                colorScheme.surfaceVariant,
-                colorScheme.background
-            )
-        )
-    }
-
+fun HomeScreen(
+    onConferenceSelected: (Conference) -> Unit,
+    onExploreGames: () -> Unit,
+    onExploreRankings: () -> Unit
+) {
     Box(
         modifier = Modifier
             .fillMaxSize()
-            .background(backgroundBrush),
-        contentAlignment = Alignment.Center
+            .background(MaterialTheme.colorScheme.background)
     ) {
         Column(
-            horizontalAlignment = Alignment.CenterHorizontally,
-            verticalArrangement = Arrangement.spacedBy(32.dp)
-        ) {
-            Column(horizontalAlignment = Alignment.CenterHorizontally) {
-                Text(
-                    text = "NFL Conference Hub",
-                    style = MaterialTheme.typography.headlineMedium,
-                    color = MaterialTheme.colorScheme.onBackground,
-                    fontWeight = FontWeight.Bold
-                )
-                Spacer(modifier = Modifier.height(8.dp))
-                Text(
-                    text = "Tap a conference letter to explore every franchise",
-                    style = MaterialTheme.typography.bodyMedium,
-                    color = MaterialTheme.colorScheme.onBackground.copy(alpha = 0.7f)
-                )
-            }
-            Row(
-                horizontalArrangement = Arrangement.spacedBy(24.dp),
-                verticalAlignment = Alignment.CenterVertically
-            ) {
-                ConferenceLetterButton(
-                    letter = "A",
-                    label = "AFC",
-                    colors = listOf(Color(0xFFD50A0A), Color(0xFF7F0000)),
-                    onClick = { onConferenceSelected(Conference.AFC) }
-                )
-                Box(
-                    modifier = Modifier
-                        .size(110.dp)
-                        .clip(CircleShape)
-                        .background(
-                            Brush.radialGradient(
-                                listOf(MaterialTheme.colorScheme.surface, MaterialTheme.colorScheme.primary.copy(alpha = 0.35f))
-                            )
-                        )
-                        .border(3.dp, MaterialTheme.colorScheme.primary, CircleShape),
-                    contentAlignment = Alignment.Center
-                ) {
-                    Text(
-                        text = "NFL",
-                        fontSize = 28.sp,
-                        fontWeight = FontWeight.Black,
-                        color = MaterialTheme.colorScheme.primary
-                    )
-                }
-                ConferenceLetterButton(
-                    letter = "N",
-                    label = "NFC",
-                    colors = listOf(Color(0xFF0B51A1), Color(0xFF001F54)),
-                    onClick = { onConferenceSelected(Conference.NFC) }
-                )
-            }
-        }
-    }
-}
-
-@Composable
-fun ConferenceLetterButton(
-    letter: String,
-    label: String,
-    colors: List<Color>,
-    onClick: () -> Unit
-) {
-    Column(horizontalAlignment = Alignment.CenterHorizontally) {
-        Box(
-            modifier = Modifier
-                .size(150.dp)
-                .clip(CircleShape)
-                .background(Brush.linearGradient(colors))
-                .border(4.dp, Color.White.copy(alpha = 0.6f), CircleShape)
-                .clickable(onClick = onClick),
-            contentAlignment = Alignment.Center
-        ) {
-            Text(
-                text = letter,
-                fontSize = 64.sp,
-                fontWeight = FontWeight.ExtraBold,
-                color = Color.White
-            )
-        }
-        Spacer(modifier = Modifier.height(12.dp))
-        Text(
-            text = label,
-            style = MaterialTheme.typography.titleMedium,
-            fontWeight = FontWeight.Bold,
-            color = MaterialTheme.colorScheme.onBackground
-        )
-    }
-}
-
-@OptIn(ExperimentalMaterial3Api::class)
-@Composable
-fun ConferenceTeamsScreen(
-    conference: Conference,
-    teams: List<Team>,
-    onBack: () -> Unit,
-    onTeamSelected: (Team) -> Unit
-) {
-    Scaffold(
-        topBar = {
-            CenterAlignedTopAppBar(
-                title = {
-                    Column(horizontalAlignment = Alignment.CenterHorizontally) {
-                        Text(text = conference.displayName, fontWeight = FontWeight.Bold)
-                        Text(
-                            text = "${teams.size} franchises",
-                            style = MaterialTheme.typography.bodySmall,
-                            color = MaterialTheme.colorScheme.onSurfaceVariant
-                        )
-                    }
-                },
-                navigationIcon = {
-                    IconButton(onClick = onBack) {
-                        Icon(Icons.Default.ArrowBack, contentDescription = "Back")
-                    }
-                }
-            )
-        }
-    ) { paddingValues ->
-        LazyColumn(
             modifier = Modifier
                 .fillMaxSize()
-                .background(MaterialTheme.colorScheme.background),
-            contentPadding = PaddingValues(20.dp),
+                .padding(horizontal = 24.dp)
+                .padding(top = 48.dp, bottom = 24.dp),
+            verticalArrangement = Arrangement.SpaceBetween
+        ) {
+            Column(verticalArrangement = Arrangement.spacedBy(24.dp)) {
+                Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
+                    Text(
+                        text = "NFL Universe",
+                        style = MaterialTheme.typography.headlineMedium,
+                        fontWeight = FontWeight.Bold
+                    )
+                    Text(
+                        text = "Explora conferencias, leyendas y datos con estilo Apple Sports + NBA 2K.",
+                        style = MaterialTheme.typography.bodyMedium,
+                        color = MaterialTheme.colorScheme.onBackground.copy(alpha = 0.75f)
+                    )
+                }
+                Box(modifier = Modifier
+                    .fillMaxWidth()
+                    .height(360.dp)
+                    .clip(RoundedCornerShape(36.dp))
+                ) {
+                    Column(Modifier.fillMaxSize()) {
+                        ConferenceHeroCard(
+                            title = "AFC",
+                            subtitle = "American Football Conference",
+                            gradient = Brush.verticalGradient(listOf(Color(0xFF8B0000), Color(0xFF360000))),
+                            logoRes = R.drawable.afc,
+                            alignment = Alignment.Center,
+                            onClick = { onConferenceSelected(Conference.AFC) },
+                            modifier = Modifier.weight(1f)
+                        )
+                        ConferenceHeroCard(
+                            title = "NFC",
+                            subtitle = "National Football Conference",
+                            gradient = Brush.verticalGradient(listOf(Color(0xFF0A2A6B), Color(0xFF001233))),
+                            logoRes = R.drawable.nfc_logo,
+                            alignment = Alignment.Center,
+                            onClick = { onConferenceSelected(Conference.NFC) },
+                            modifier = Modifier.weight(1f)
+                        )
+                    }
+                    Image(
+                        painter = painterResource(id = R.drawable.nfl),
+                        contentDescription = "NFL shield",
+                        modifier = Modifier
+                            .size(120.dp)
+                            .align(Alignment.Center)
+                    )
+                }
+            }
+            Column(verticalArrangement = Arrangement.spacedBy(16.dp)) {
+                Text(
+                    text = "Accesos rápidos",
+                    style = MaterialTheme.typography.titleMedium,
+                    fontWeight = FontWeight.SemiBold
+                )
+                Row(
+                    horizontalArrangement = Arrangement.spacedBy(16.dp),
+                    modifier = Modifier.fillMaxWidth()
+                ) {
+                    QuickActionButton(label = "Partidos", description = "Resultados y próximos duelos", onClick = onExploreGames)
+                    QuickActionButton(label = "GOAT Charts", description = "Ranking histórico", onClick = onExploreRankings)
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun QuickActionButton(label: String, description: String, onClick: () -> Unit) {
+    Card(
+        modifier = Modifier
+            .weight(1f)
+            .height(120.dp)
+            .clip(RoundedCornerShape(24.dp))
+            .clickable(onClick = onClick),
+        colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surface)
+    ) {
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(16.dp),
+            verticalArrangement = Arrangement.SpaceBetween
+        ) {
+            Text(text = label, style = MaterialTheme.typography.titleMedium, fontWeight = FontWeight.Bold)
+            Text(
+                text = description,
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant
+            )
+        }
+    }
+}
+
+@Composable
+private fun ConferenceHeroCard(
+    title: String,
+    subtitle: String,
+    gradient: Brush,
+    logoRes: Int,
+    alignment: Alignment,
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier
+) {
+    Box(
+        modifier = modifier
+            .fillMaxWidth()
+            .clip(RoundedCornerShape(36.dp))
+            .background(gradient)
+            .clickable(onClick = onClick),
+        contentAlignment = alignment
+    ) {
+        Image(
+            painter = painterResource(id = logoRes),
+            contentDescription = "$title logo",
+            modifier = Modifier.size(140.dp)
+        )
+        Column(
+            modifier = Modifier
+                .align(Alignment.TopStart)
+                .padding(24.dp)
+        ) {
+            Text(text = title, style = MaterialTheme.typography.headlineSmall, fontWeight = FontWeight.Black)
+            Text(text = subtitle, style = MaterialTheme.typography.bodySmall)
+        }
+    }
+}
+
+@Composable
+fun TeamsScreen(
+    initialConference: Conference,
+    onTeamSelected: (Team) -> Unit,
+    onPlayerSelected: (Team, PlayerProfile) -> Unit
+) {
+    var selectedConference by remember { mutableStateOf(initialConference) }
+    LaunchedEffect(initialConference) {
+        selectedConference = initialConference
+    }
+    val teams = remember(selectedConference) { TeamsRepository.getTeamsForConference(selectedConference) }
+
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .background(MaterialTheme.colorScheme.background)
+    ) {
+        Spacer(modifier = Modifier.height(16.dp))
+        Text(
+            text = "Franquicias ${selectedConference.name}",
+            style = MaterialTheme.typography.titleLarge,
+            fontWeight = FontWeight.Bold,
+            modifier = Modifier.padding(horizontal = 24.dp, vertical = 8.dp)
+        )
+        TabRow(
+            selectedTabIndex = Conference.entries.indexOf(selectedConference),
+            containerColor = Color.Transparent,
+            contentColor = MaterialTheme.colorScheme.primary
+        ) {
+            Conference.entries.forEach { conference ->
+                val selected = conference == selectedConference
+                Tab(
+                    selected = selected,
+                    onClick = { selectedConference = conference },
+                    text = {
+                        Text(
+                            text = conference.name,
+                            fontWeight = if (selected) FontWeight.Bold else FontWeight.Normal
+                        )
+                    }
+                )
+            }
+        }
+        LazyColumn(
+            modifier = Modifier.fillMaxSize(),
+            contentPadding = PaddingValues(horizontal = 24.dp, vertical = 16.dp),
             verticalArrangement = Arrangement.spacedBy(16.dp)
         ) {
             items(teams) { team ->
-                TeamCard(team = team, onClick = { onTeamSelected(team) })
-            }
-            item {
-                Spacer(modifier = Modifier.height(paddingValues.calculateBottomPadding()))
+                TeamCard(
+                    team = team,
+                    onClick = { onTeamSelected(team) },
+                    onPlayerSelected = { profile -> onPlayerSelected(team, profile) }
+                )
             }
         }
     }
 }
 
 @Composable
-fun TeamCard(team: Team, onClick: () -> Unit) {
+fun TeamCard(
+    team: Team,
+    onClick: () -> Unit,
+    onPlayerSelected: (PlayerProfile) -> Unit
+) {
     val gradient = remember(team.primaryColor, team.secondaryColor) {
         Brush.linearGradient(listOf(team.primaryColor, team.secondaryColor))
     }
-    Row(
+    Card(
         modifier = Modifier
             .fillMaxWidth()
-            .clip(RoundedCornerShape(20.dp))
-            .background(gradient)
-            .clickable(onClick = onClick)
-            .padding(18.dp),
-        verticalAlignment = Alignment.CenterVertically,
-        horizontalArrangement = Arrangement.spacedBy(16.dp)
+            .clip(RoundedCornerShape(28.dp))
+            .clickable(onClick = onClick),
+        colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surface)
     ) {
-        TeamLogo(team)
-        Column(
-            verticalArrangement = Arrangement.spacedBy(4.dp)
-        ) {
-            Text(
-                text = "${team.city} ${team.name}",
-                style = MaterialTheme.typography.titleMedium,
-                fontWeight = FontWeight.SemiBold,
-                color = team.textColor
-            )
-            Text(
-                text = team.championships,
-                style = MaterialTheme.typography.bodySmall,
-                color = team.textColor.copy(alpha = 0.85f),
-                maxLines = 2,
-                overflow = TextOverflow.Ellipsis
-            )
+        Column(modifier = Modifier.padding(20.dp), verticalArrangement = Arrangement.spacedBy(16.dp)) {
+            Row(
+                horizontalArrangement = Arrangement.spacedBy(16.dp),
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                TeamLogo(team = team, size = 72.dp)
+                Column(verticalArrangement = Arrangement.spacedBy(4.dp)) {
+                    Text(
+                        text = "${team.city} ${team.name}",
+                        style = MaterialTheme.typography.titleMedium,
+                        fontWeight = FontWeight.SemiBold
+                    )
+                    Text(
+                        text = team.championships,
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        maxLines = 2,
+                        overflow = TextOverflow.Ellipsis
+                    )
+                }
+            }
+            Box(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .clip(RoundedCornerShape(18.dp))
+                    .background(gradient)
+                    .padding(16.dp)
+            ) {
+                Text(
+                    text = team.history,
+                    style = MaterialTheme.typography.bodySmall,
+                    color = team.textColor,
+                    maxLines = 3,
+                    overflow = TextOverflow.Ellipsis
+                )
+            }
+            Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
+                Text(
+                    text = "Jugadores insignia",
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                )
+                PlayersRepository.highlightsFor(team).forEach { profile ->
+                    PlayerPill(profile = profile, onClick = { onPlayerSelected(profile) })
+                }
+            }
         }
     }
 }
 
 @Composable
-fun TeamLogo(team: Team) {
-    val logoBrush = remember(team.primaryColor, team.secondaryColor) {
-        Brush.radialGradient(listOf(team.secondaryColor, team.primaryColor))
-    }
-    Box(
-        modifier = Modifier
-            .size(64.dp)
-            .clip(CircleShape)
-            .background(logoBrush)
-            .border(3.dp, Color.White.copy(alpha = 0.7f), CircleShape),
-        contentAlignment = Alignment.Center
+fun TeamLogo(team: Team, size: Dp = 96.dp) {
+    val logoRes = remember(team.id) { LogoAssets.teamLogo(team.id) }
+    Card(
+        shape = CircleShape,
+        colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surfaceVariant),
+        modifier = Modifier.size(size)
     ) {
+        Image(
+            painter = painterResource(id = logoRes),
+            contentDescription = "${team.name} logo",
+            modifier = Modifier.padding(12.dp)
+        )
+    }
+}
+
+@Composable
+private fun PlayerPill(profile: PlayerProfile, onClick: () -> Unit) {
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .clip(RoundedCornerShape(50))
+            .background(MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.35f))
+            .clickable(onClick = onClick)
+            .padding(horizontal = 16.dp, vertical = 12.dp),
+        horizontalArrangement = Arrangement.SpaceBetween,
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        Column {
+            Text(text = profile.name, style = MaterialTheme.typography.bodyMedium, fontWeight = FontWeight.SemiBold)
+            Text(
+                text = profile.position,
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant
+            )
+        }
         Text(
-            text = team.abbreviation,
-            fontSize = 20.sp,
-            fontWeight = FontWeight.Bold,
-            color = team.textColor
+            text = "Ver historia",
+            style = MaterialTheme.typography.bodySmall,
+            color = MaterialTheme.colorScheme.primary,
+            textDecoration = TextDecoration.Underline
         )
     }
 }
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
-fun TeamDetailScreen(team: Team, onBack: () -> Unit) {
+fun TeamDetailScreen(
+    team: Team,
+    onPlayerSelected: (PlayerProfile) -> Unit,
+    onBack: () -> Unit
+) {
     Scaffold(
         topBar = {
             CenterAlignedTopAppBar(
@@ -828,7 +1486,7 @@ fun TeamDetailScreen(team: Team, onBack: () -> Unit) {
                     Column(horizontalAlignment = Alignment.CenterHorizontally) {
                         Text(text = "${team.city} ${team.name}", fontWeight = FontWeight.Bold)
                         Text(
-                            text = "Established ${team.established}",
+                            text = "Desde ${team.established}",
                             style = MaterialTheme.typography.bodySmall,
                             color = MaterialTheme.colorScheme.onSurfaceVariant
                         )
@@ -836,7 +1494,7 @@ fun TeamDetailScreen(team: Team, onBack: () -> Unit) {
                 },
                 navigationIcon = {
                     IconButton(onClick = onBack) {
-                        Icon(Icons.Default.ArrowBack, contentDescription = "Back")
+                        Icon(Icons.Default.ArrowBack, contentDescription = "Regresar")
                     }
                 }
             )
@@ -853,22 +1511,17 @@ fun TeamDetailScreen(team: Team, onBack: () -> Unit) {
                 Box(
                     modifier = Modifier
                         .fillMaxWidth()
-                        .clip(RoundedCornerShape(24.dp))
-                        .background(
-                            Brush.linearGradient(listOf(team.primaryColor, team.secondaryColor))
-                        )
+                        .clip(RoundedCornerShape(32.dp))
+                        .background(Brush.linearGradient(listOf(team.primaryColor, team.secondaryColor)))
                         .padding(24.dp)
                 ) {
-                    Column(
-                        verticalArrangement = Arrangement.spacedBy(12.dp),
-                        horizontalAlignment = Alignment.CenterHorizontally
-                    ) {
-                        TeamLogo(team)
+                    Column(horizontalAlignment = Alignment.CenterHorizontally, verticalArrangement = Arrangement.spacedBy(16.dp)) {
+                        TeamLogo(team = team)
                         Text(
                             text = team.championships,
-                            color = team.textColor,
-                            style = MaterialTheme.typography.bodyMedium,
+                            style = MaterialTheme.typography.titleSmall,
                             fontWeight = FontWeight.SemiBold,
+                            color = team.textColor,
                             textAlign = TextAlign.Center
                         )
                     }
@@ -876,49 +1529,430 @@ fun TeamDetailScreen(team: Team, onBack: () -> Unit) {
             }
             item {
                 Column(verticalArrangement = Arrangement.spacedBy(12.dp)) {
-                    Text(
-                        text = "Franchise History",
-                        style = MaterialTheme.typography.titleMedium,
-                        fontWeight = FontWeight.SemiBold
-                    )
+                    Text(text = "Historia de la franquicia", style = MaterialTheme.typography.titleMedium, fontWeight = FontWeight.SemiBold)
                     Text(
                         text = team.history,
                         style = MaterialTheme.typography.bodyMedium,
-                        color = MaterialTheme.colorScheme.onBackground.copy(alpha = 0.85f)
+                        color = MaterialTheme.colorScheme.onBackground.copy(alpha = 0.9f)
                     )
                 }
             }
             item {
                 Column(verticalArrangement = Arrangement.spacedBy(12.dp)) {
-                    Text(
-                        text = "Notable Players",
-                        style = MaterialTheme.typography.titleMedium,
-                        fontWeight = FontWeight.SemiBold
-                    )
-                    Column(verticalArrangement = Arrangement.spacedBy(6.dp)) {
-                        team.notablePlayers.forEach { player ->
-                            Row(
-                                verticalAlignment = Alignment.CenterVertically,
-                                horizontalArrangement = Arrangement.spacedBy(8.dp)
-                            ) {
-                                Box(
-                                    modifier = Modifier
-                                        .size(10.dp)
-                                        .clip(CircleShape)
-                                        .background(team.primaryColor)
-                                )
-                                Text(
-                                    text = player,
-                                    style = MaterialTheme.typography.bodyMedium,
-                                    color = MaterialTheme.colorScheme.onBackground
-                                )
-                            }
-                        }
+                    Text(text = "Jugadores destacados", style = MaterialTheme.typography.titleMedium, fontWeight = FontWeight.SemiBold)
+                    PlayersRepository.highlightsFor(team).forEach { profile ->
+                        PlayerPill(profile = profile, onClick = { onPlayerSelected(profile) })
                     }
                 }
             }
             item {
+                Divider()
+            }
+            item {
+                Text(
+                    text = "Colores icónicos",
+                    style = MaterialTheme.typography.titleSmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                )
+                Row(horizontalArrangement = Arrangement.spacedBy(12.dp)) {
+                    ColorSwatch(team.primaryColor, "Primario")
+                    ColorSwatch(team.secondaryColor, "Secundario")
+                }
+            }
+            item {
                 Spacer(modifier = Modifier.height(paddingValues.calculateBottomPadding()))
+            }
+        }
+    }
+}
+
+@Composable
+private fun ColorSwatch(color: Color, label: String) {
+    Column(horizontalAlignment = Alignment.CenterHorizontally) {
+        Box(
+            modifier = Modifier
+                .size(48.dp)
+                .clip(RoundedCornerShape(12.dp))
+                .background(color)
+        )
+        Spacer(modifier = Modifier.height(4.dp))
+        Text(text = label, style = MaterialTheme.typography.labelSmall)
+    }
+}
+
+@Composable
+fun PlayerDetailScreen(team: Team, profile: PlayerProfile, onBack: () -> Unit) {
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .background(MaterialTheme.colorScheme.background)
+            .padding(24.dp)
+    ) {
+        IconButton(onClick = onBack) {
+            Icon(Icons.Default.ArrowBack, contentDescription = "Regresar")
+        }
+        Spacer(modifier = Modifier.height(16.dp))
+        Card(
+            modifier = Modifier.fillMaxWidth(),
+            colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surface),
+            shape = RoundedCornerShape(28.dp)
+        ) {
+            Column(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(24.dp),
+                verticalArrangement = Arrangement.spacedBy(16.dp),
+                horizontalAlignment = Alignment.CenterHorizontally
+            ) {
+                TeamLogo(team = team, size = 100.dp)
+                Text(text = profile.name, style = MaterialTheme.typography.headlineSmall, fontWeight = FontWeight.Bold)
+                Text(text = profile.position, style = MaterialTheme.typography.bodySmall, color = MaterialTheme.colorScheme.onSurfaceVariant)
+                Text(
+                    text = profile.awards,
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.primary,
+                    textAlign = TextAlign.Center
+                )
+                Text(
+                    text = profile.biography,
+                    style = MaterialTheme.typography.bodyMedium,
+                    textAlign = TextAlign.Center
+                )
+            }
+        }
+    }
+}
+
+@Composable
+fun GamesScreen(onGameSelected: (Game) -> Unit) {
+    val finals = remember { GamesRepository.gamesByStatus(GameStatus.Final) }
+    val upcoming = remember { GamesRepository.gamesByStatus(GameStatus.Upcoming) }
+
+    LazyColumn(
+        modifier = Modifier
+            .fillMaxSize()
+            .background(MaterialTheme.colorScheme.background),
+        contentPadding = PaddingValues(horizontal = 24.dp, vertical = 24.dp),
+        verticalArrangement = Arrangement.spacedBy(24.dp)
+    ) {
+        item {
+            Text(text = "Partidos finalizados", style = MaterialTheme.typography.titleMedium, fontWeight = FontWeight.SemiBold)
+        }
+        items(finals) { game ->
+            GameCard(game = game, onClick = { onGameSelected(game) })
+        }
+        item {
+            Text(text = "Próximos partidos", style = MaterialTheme.typography.titleMedium, fontWeight = FontWeight.SemiBold)
+        }
+        items(upcoming) { game ->
+            GameCard(game = game, onClick = { onGameSelected(game) })
+        }
+    }
+}
+
+@Composable
+private fun GameCard(game: Game, onClick: () -> Unit) {
+    val homeTeam = TeamsRepository.getTeamById(game.homeTeamId)
+    val awayTeam = TeamsRepository.getTeamById(game.awayTeamId)
+    val gradient = if (homeTeam != null && awayTeam != null) {
+        Brush.horizontalGradient(listOf(homeTeam.primaryColor, awayTeam.primaryColor))
+    } else {
+        Brush.horizontalGradient(listOf(MaterialTheme.colorScheme.surfaceVariant, MaterialTheme.colorScheme.surface))
+    }
+    Card(
+        modifier = Modifier
+            .fillMaxWidth()
+            .clip(RoundedCornerShape(28.dp))
+            .clickable(onClick = onClick),
+        colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surface)
+    ) {
+        Column(modifier = Modifier.padding(20.dp), verticalArrangement = Arrangement.spacedBy(16.dp)) {
+            Box(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .clip(RoundedCornerShape(18.dp))
+                    .background(gradient)
+                    .padding(16.dp)
+            ) {
+                Column(Modifier.fillMaxWidth(), horizontalAlignment = Alignment.CenterHorizontally) {
+                    Text(text = game.date, style = MaterialTheme.typography.bodySmall, color = Color.White.copy(alpha = 0.85f))
+                    Spacer(modifier = Modifier.height(12.dp))
+                    Row(
+                        horizontalArrangement = Arrangement.SpaceEvenly,
+                        verticalAlignment = Alignment.CenterVertically,
+                        modifier = Modifier.fillMaxWidth()
+                    ) {
+                        GameTeamLogo(team = homeTeam, size = 56.dp)
+                        Column(horizontalAlignment = Alignment.CenterHorizontally) {
+                            Text(text = if (game.homeScore != null) "${game.homeScore} - ${game.awayScore}" else "VS", style = MaterialTheme.typography.titleLarge, fontWeight = FontWeight.Black, color = Color.White)
+                            Text(text = game.location, style = MaterialTheme.typography.bodySmall, color = Color.White.copy(alpha = 0.7f))
+                        }
+                        GameTeamLogo(team = awayTeam, size = 56.dp)
+                    }
+                }
+            }
+            Row(horizontalArrangement = Arrangement.SpaceBetween, modifier = Modifier.fillMaxWidth()) {
+                Column {
+                    Text(text = homeTeam?.abbreviation ?: "HOME", fontWeight = FontWeight.SemiBold)
+                    Text(text = game.homeRecord, style = MaterialTheme.typography.bodySmall, color = MaterialTheme.colorScheme.onSurfaceVariant)
+                }
+                Column(horizontalAlignment = Alignment.End) {
+                    Text(text = awayTeam?.abbreviation ?: "AWAY", fontWeight = FontWeight.SemiBold)
+                    Text(text = game.awayRecord, style = MaterialTheme.typography.bodySmall, color = MaterialTheme.colorScheme.onSurfaceVariant)
+                }
+            }
+            Text(text = "Odds: ${game.odds}", style = MaterialTheme.typography.bodySmall, color = MaterialTheme.colorScheme.primary)
+            Button(
+                onClick = onClick,
+                colors = ButtonDefaults.buttonColors(containerColor = MaterialTheme.colorScheme.primary)
+            ) {
+                Text(text = "Detalles")
+            }
+        }
+    }
+}
+
+@Composable
+private fun GameTeamLogo(team: Team?, size: Dp) {
+    if (team != null) {
+        TeamLogo(team = team, size = size)
+    } else {
+        Box(
+            modifier = Modifier
+                .size(size)
+                .clip(CircleShape)
+                .background(MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.6f)),
+            contentAlignment = Alignment.Center
+        ) {
+            Text(
+                text = "NFL",
+                style = MaterialTheme.typography.labelSmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant
+            )
+        }
+    }
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun GameDetailScreen(game: Game, onBack: () -> Unit) {
+    val homeTeam = TeamsRepository.getTeamById(game.homeTeamId)
+    val awayTeam = TeamsRepository.getTeamById(game.awayTeamId)
+    Scaffold(
+        topBar = {
+            CenterAlignedTopAppBar(
+                title = {
+                    Text(text = "Game Center", fontWeight = FontWeight.Bold)
+                },
+                navigationIcon = {
+                    IconButton(onClick = onBack) {
+                        Icon(Icons.Default.ArrowBack, contentDescription = "Regresar")
+                    }
+                }
+            )
+        }
+    ) { paddingValues ->
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(paddingValues)
+                .background(MaterialTheme.colorScheme.background)
+                .padding(24.dp),
+            verticalArrangement = Arrangement.spacedBy(24.dp)
+        ) {
+            Box(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .height(200.dp)
+                    .clip(RoundedCornerShape(32.dp))
+                    .background(
+                        Brush.horizontalGradient(
+                            listOf(
+                                homeTeam?.primaryColor ?: MaterialTheme.colorScheme.primary,
+                                awayTeam?.primaryColor ?: MaterialTheme.colorScheme.tertiary
+                            )
+                        )
+                    )
+                    .padding(24.dp)
+            ) {
+                Row(
+                    modifier = Modifier.fillMaxSize(),
+                    horizontalArrangement = Arrangement.SpaceAround,
+                    verticalAlignment = Alignment.CenterVertically
+                ) {
+                    if (homeTeam != null) TeamLogo(team = homeTeam, size = 80.dp)
+                    Column(horizontalAlignment = Alignment.CenterHorizontally) {
+                        Text(text = "VS", style = MaterialTheme.typography.titleLarge, fontWeight = FontWeight.Black, color = Color.White)
+                        Text(
+                            text = if (game.homeScore != null) "${game.homeScore} - ${game.awayScore}" else game.date,
+                            style = MaterialTheme.typography.headlineSmall,
+                            color = Color.White
+                        )
+                    }
+                    if (awayTeam != null) TeamLogo(team = awayTeam, size = 80.dp)
+                }
+            }
+            Column(verticalArrangement = Arrangement.spacedBy(12.dp)) {
+                Text(text = "Estadísticas clave", style = MaterialTheme.typography.titleMedium, fontWeight = FontWeight.SemiBold)
+                game.keyStats.forEach { (label, value) ->
+                    Row(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .clip(RoundedCornerShape(18.dp))
+                            .background(MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.4f))
+                            .padding(16.dp),
+                        horizontalArrangement = Arrangement.SpaceBetween
+                    ) {
+                        Text(text = label, fontWeight = FontWeight.SemiBold)
+                        Text(text = value, color = MaterialTheme.colorScheme.onSurfaceVariant)
+                    }
+                }
+            }
+            Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
+                Text(text = "Standings divisionales", style = MaterialTheme.typography.titleMedium, fontWeight = FontWeight.SemiBold)
+                game.divisionStandings.forEach { standing ->
+                    val team = TeamsRepository.getTeamById(standing.teamId)
+                    Row(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .padding(vertical = 6.dp),
+                        horizontalArrangement = Arrangement.SpaceBetween
+                    ) {
+                        Text(text = team?.abbreviation ?: standing.teamId.uppercase(), fontWeight = FontWeight.SemiBold)
+                        Text(text = standing.record, style = MaterialTheme.typography.bodySmall)
+                        Text(text = standing.trend, style = MaterialTheme.typography.bodySmall, color = MaterialTheme.colorScheme.primary)
+                    }
+                }
+            }
+            Text(text = "Odds de apuestas: ${game.odds}", style = MaterialTheme.typography.bodyMedium, color = MaterialTheme.colorScheme.primary)
+        }
+    }
+}
+
+@Composable
+fun RankingsScreen(onTeamSelected: (String) -> Unit) {
+    LazyColumn(
+        modifier = Modifier
+            .fillMaxSize()
+            .background(MaterialTheme.colorScheme.background),
+        contentPadding = PaddingValues(horizontal = 24.dp, vertical = 24.dp),
+        verticalArrangement = Arrangement.spacedBy(24.dp)
+    ) {
+        item {
+            Text(text = "GOAT Players", style = MaterialTheme.typography.titleLarge, fontWeight = FontWeight.Bold)
+        }
+        items(GoatRankingsRepository.goatPlayers) { player ->
+            RankingCard(
+                title = "${player.rank}. ${player.name}",
+                subtitle = "${player.position} · Debut ${player.debutYear}",
+                teamId = player.teamId,
+                onClick = { onTeamSelected(player.teamId) }
+            )
+        }
+        item {
+            Text(text = "GOAT Teams", style = MaterialTheme.typography.titleLarge, fontWeight = FontWeight.Bold)
+        }
+        items(GoatRankingsRepository.goatTeams) { team ->
+            RankingCard(
+                title = "${team.rank}. ${team.name}",
+                subtitle = "Temporada ${team.season}",
+                teamId = team.teamId,
+                onClick = { onTeamSelected(team.teamId) }
+            )
+        }
+    }
+}
+
+@Composable
+private fun RankingCard(title: String, subtitle: String, teamId: String, onClick: () -> Unit) {
+    val team = TeamsRepository.getTeamById(teamId)
+    Card(
+        modifier = Modifier
+            .fillMaxWidth()
+            .clip(RoundedCornerShape(24.dp))
+            .clickable(onClick = onClick),
+        colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surface)
+    ) {
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(16.dp),
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.spacedBy(16.dp)
+        ) {
+            if (team != null) {
+                TeamLogo(team = team, size = 64.dp)
+            } else {
+                Box(
+                    modifier = Modifier
+                        .size(64.dp)
+                        .clip(CircleShape)
+                        .background(MaterialTheme.colorScheme.surfaceVariant)
+                )
+            }
+            Column {
+                Text(text = title, style = MaterialTheme.typography.titleMedium, fontWeight = FontWeight.SemiBold)
+                Text(text = subtitle, style = MaterialTheme.typography.bodySmall, color = MaterialTheme.colorScheme.onSurfaceVariant)
+            }
+        }
+    }
+}
+
+@Composable
+fun StatsScreen() {
+    val categories = remember { StatsRepository.categories }
+    LazyColumn(
+        modifier = Modifier
+            .fillMaxSize()
+            .background(MaterialTheme.colorScheme.background),
+        contentPadding = PaddingValues(horizontal = 24.dp, vertical = 24.dp),
+        verticalArrangement = Arrangement.spacedBy(24.dp)
+    ) {
+        items(categories) { category ->
+            StatsTable(category)
+        }
+    }
+}
+
+@Composable
+private fun StatsTable(category: StatCategory) {
+    Card(
+        modifier = Modifier.fillMaxWidth(),
+        colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surface),
+        shape = RoundedCornerShape(24.dp)
+    ) {
+        Column(modifier = Modifier.padding(16.dp), verticalArrangement = Arrangement.spacedBy(12.dp)) {
+            Text(text = category.title, style = MaterialTheme.typography.titleMedium, fontWeight = FontWeight.SemiBold)
+            Row(modifier = Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.SpaceBetween) {
+                category.headers.forEach { header ->
+                    Text(
+                        text = header,
+                        style = MaterialTheme.typography.labelSmall,
+                        fontWeight = FontWeight.Bold,
+                        modifier = Modifier.weight(1f),
+                        maxLines = 1
+                    )
+                }
+            }
+            category.rows.forEach { row ->
+                Row(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .clip(RoundedCornerShape(12.dp))
+                        .background(MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.35f))
+                        .padding(12.dp),
+                    horizontalArrangement = Arrangement.SpaceBetween
+                ) {
+                    Text(text = row.label, modifier = Modifier.weight(1.6f), style = MaterialTheme.typography.bodySmall)
+                    row.values.forEach { value ->
+                        Text(
+                            text = value,
+                            modifier = Modifier.weight(1f),
+                            style = MaterialTheme.typography.bodySmall,
+                            textAlign = TextAlign.End
+                        )
+                    }
+                }
             }
         }
     }

--- a/app/src/main/java/com/example/practicas/ui/theme/Type.kt
+++ b/app/src/main/java/com/example/practicas/ui/theme/Type.kt
@@ -8,27 +8,60 @@ import androidx.compose.ui.unit.sp
 
 // Set of Material typography styles to start with
 val Typography = Typography(
-    bodyLarge = TextStyle(
-        fontFamily = FontFamily.Default,
-        fontWeight = FontWeight.Normal,
-        fontSize = 16.sp,
-        lineHeight = 24.sp,
-        letterSpacing = 0.5.sp
-    )
-    /* Other default text styles to override
+    displayLarge = TextStyle(
+        fontFamily = FontFamily.SansSerif,
+        fontWeight = FontWeight.Black,
+        fontSize = 48.sp,
+        lineHeight = 52.sp,
+        letterSpacing = (-0.5f).sp
+    ),
+    headlineMedium = TextStyle(
+        fontFamily = FontFamily.SansSerif,
+        fontWeight = FontWeight.SemiBold,
+        fontSize = 28.sp,
+        lineHeight = 32.sp,
+        letterSpacing = (-0.25f).sp
+    ),
     titleLarge = TextStyle(
-        fontFamily = FontFamily.Default,
-        fontWeight = FontWeight.Normal,
+        fontFamily = FontFamily.SansSerif,
+        fontWeight = FontWeight.SemiBold,
         fontSize = 22.sp,
         lineHeight = 28.sp,
         letterSpacing = 0.sp
     ),
+    titleMedium = TextStyle(
+        fontFamily = FontFamily.SansSerif,
+        fontWeight = FontWeight.Medium,
+        fontSize = 18.sp,
+        lineHeight = 24.sp,
+        letterSpacing = 0.15.sp
+    ),
+    bodyLarge = TextStyle(
+        fontFamily = FontFamily.SansSerif,
+        fontWeight = FontWeight.Normal,
+        fontSize = 16.sp,
+        lineHeight = 24.sp,
+        letterSpacing = 0.15.sp
+    ),
+    bodyMedium = TextStyle(
+        fontFamily = FontFamily.SansSerif,
+        fontWeight = FontWeight.Normal,
+        fontSize = 14.sp,
+        lineHeight = 20.sp,
+        letterSpacing = 0.1.sp
+    ),
+    bodySmall = TextStyle(
+        fontFamily = FontFamily.SansSerif,
+        fontWeight = FontWeight.Normal,
+        fontSize = 12.sp,
+        lineHeight = 16.sp,
+        letterSpacing = 0.1.sp
+    ),
     labelSmall = TextStyle(
-        fontFamily = FontFamily.Default,
+        fontFamily = FontFamily.SansSerif,
         fontWeight = FontWeight.Medium,
         fontSize = 11.sp,
-        lineHeight = 16.sp,
+        lineHeight = 14.sp,
         letterSpacing = 0.5.sp
     )
-    */
 )


### PR DESCRIPTION
## Summary
- replace the Compose navigation with a multi-tab dark UI covering home, teams, games, GOAT rankings, and stats screens styled with navy, black, red, and blue gradients
- implement repositories for players, games, historical rankings, and stat tables so users can tap through teams, players, and matchups for rich mock data
- refresh typography with a clean sans-serif scale to evoke the Apple Sports x NBA 2K minimal aesthetic

## Testing
- ./gradlew build *(fails: Android SDK not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68dcc1cec6c8832685e38fd710bcb112